### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/01125147/daa36a4e-53ec-4565-9cc6-9b96d78f75ac/415417b0-d124-45e6-8920-de42daa3758c/_apis/work/boardbadge/231d28f3-15d4-4228-aad9-1a3b5f327616)](https://dev.azure.com/01125147/daa36a4e-53ec-4565-9cc6-9b96d78f75ac/_boards/board/t/415417b0-d124-45e6-8920-de42daa3758c/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#197](https://dev.azure.com/01125147/daa36a4e-53ec-4565-9cc6-9b96d78f75ac/_workitems/edit/197). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.